### PR TITLE
feat: add collapsible visitor map in footer

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -119,7 +119,24 @@
 </main>
 
 <footer>
-  <p>&copy; 2026 Zihan Wang &nbsp;&middot;&nbsp; Last updated April 2026</p>
+  <div class="footer-row">
+    <div class="footer-meta">&copy; 2026 Zihan Wang &nbsp;&middot;&nbsp; Last updated April 2026</div>
+    <details class="visitor-details">
+      <summary class="visitor-summary">
+        <span class="visitor-label">Global readership</span>
+      </summary>
+      <div class="visitor-panel">
+        <div class="visitor-panel-head">
+          <div class="visitor-title">Readers around the world</div>
+          <div class="visitor-subtitle">Tracked since 2023 · click the map for details</div>
+        </div>
+        <div class="visitor-widget-shell">
+          <script type="text/javascript" id="clustrmaps" src="//clustrmaps.com/map_v2.js?d=o89zY8a0ARtuHIK-X34murs3PrRBFGrB1jTX7j2kYt8&cl=ffffff&w=a"></script>
+        </div>
+        <a class="visitor-external" id="visitor-external" href="#" target="_blank" rel="noopener" hidden>Open interactive map ↗</a>
+      </div>
+    </details>
+  </div>
 </footer>
 
 <script>
@@ -137,6 +154,25 @@
     document.documentElement.setAttribute('data-theme', next);
     localStorage.setItem('theme', next);
   });
+
+  (function wireVisitorMap() {
+    const shell = document.querySelector('.visitor-widget-shell');
+    const external = document.getElementById('visitor-external');
+    if (!shell || !external) return;
+    const promote = () => {
+      const anchor = shell.querySelector('a[href]');
+      if (!anchor) return false;
+      anchor.setAttribute('target', '_blank');
+      anchor.setAttribute('rel', 'noopener');
+      external.href = anchor.href;
+      external.hidden = false;
+      return true;
+    };
+    if (promote()) return;
+    const obs = new MutationObserver(() => { if (promote()) obs.disconnect(); });
+    obs.observe(shell, { childList: true, subtree: true });
+    setTimeout(() => obs.disconnect(), 8000);
+  })();
 </script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -542,7 +542,24 @@
 
 <!-- ── Footer ── -->
 <footer>
-  <p>&copy; 2026 Zihan Wang &nbsp;&middot;&nbsp; Last updated April 2026</p>
+  <div class="footer-row">
+    <div class="footer-meta">&copy; 2026 Zihan Wang &nbsp;&middot;&nbsp; Last updated April 2026</div>
+    <details class="visitor-details">
+      <summary class="visitor-summary">
+        <span class="visitor-label">Global readership</span>
+      </summary>
+      <div class="visitor-panel">
+        <div class="visitor-panel-head">
+          <div class="visitor-title">Readers around the world</div>
+          <div class="visitor-subtitle">Tracked since 2023 · click the map for details</div>
+        </div>
+        <div class="visitor-widget-shell">
+          <script type="text/javascript" id="clustrmaps" src="//clustrmaps.com/map_v2.js?d=o89zY8a0ARtuHIK-X34murs3PrRBFGrB1jTX7j2kYt8&cl=ffffff&w=a"></script>
+        </div>
+        <a class="visitor-external" id="visitor-external" href="#" target="_blank" rel="noopener" hidden>Open interactive map ↗</a>
+      </div>
+    </details>
+  </div>
 </footer>
 
 <script>
@@ -696,6 +713,26 @@
     document.documentElement.setAttribute('data-theme', next);
     localStorage.setItem('theme', next);
   });
+
+  // ── Surface the ClustrMaps dashboard link once the widget injects its anchor ──
+  (function wireVisitorMap() {
+    const shell = document.querySelector('.visitor-widget-shell');
+    const external = document.getElementById('visitor-external');
+    if (!shell || !external) return;
+    const promote = () => {
+      const anchor = shell.querySelector('a[href]');
+      if (!anchor) return false;
+      anchor.setAttribute('target', '_blank');
+      anchor.setAttribute('rel', 'noopener');
+      external.href = anchor.href;
+      external.hidden = false;
+      return true;
+    };
+    if (promote()) return;
+    const obs = new MutationObserver(() => { if (promote()) obs.disconnect(); });
+    obs.observe(shell, { childList: true, subtree: true });
+    setTimeout(() => obs.disconnect(), 8000);
+  })();
 </script>
 
 </body>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -650,12 +650,107 @@ html[data-theme="dark"] .bio-recruit strong { color: #ff6b6b; }
 /* ── Footer ── */
 footer {
   border-top: 1px solid var(--border);
-  text-align: center;
-  padding: 24px;
+  padding: 20px 24px 28px;
   font-size: 12.5px;
   color: var(--text-faint);
 }
 footer a { color: var(--text-muted); }
+
+.footer-row {
+  max-width: 1080px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 16px;
+  align-items: start;
+}
+.footer-meta { color: var(--text-faint); line-height: 1.6; }
+
+.visitor-details { justify-self: end; }
+.visitor-details summary { list-style: none; cursor: pointer; }
+.visitor-details summary::-webkit-details-marker { display: none; }
+
+.visitor-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  transition: background .18s ease, border-color .18s ease, color .18s ease, transform .18s ease;
+}
+.visitor-summary::after {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(45deg) translate(-1px, -1px);
+  transition: transform .2s ease;
+  opacity: 0.6;
+}
+.visitor-details[open] .visitor-summary::after {
+  transform: rotate(-135deg) translate(-1px, -1px);
+}
+.visitor-summary:hover {
+  border-color: var(--purple);
+  color: var(--purple);
+  transform: translateY(-1px);
+}
+.visitor-label { letter-spacing: 0.01em; }
+
+.visitor-panel {
+  margin-top: 12px;
+  padding: 16px;
+  width: min(420px, 92vw);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--bg-alt);
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.06);
+}
+html[data-theme="dark"] .visitor-panel {
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.22);
+}
+
+.visitor-title { font-size: 13.5px; font-weight: 600; color: var(--text); }
+.visitor-subtitle { margin-top: 4px; font-size: 11.5px; color: var(--text-faint); }
+
+.visitor-widget-shell {
+  margin-top: 14px;
+  overflow: hidden;
+  border-radius: 12px;
+  opacity: 0.82;
+  transition: opacity .2s ease;
+  cursor: pointer;
+}
+.visitor-widget-shell:hover { opacity: 1; }
+.visitor-widget-shell img { max-width: 100%; height: auto; display: block; }
+.visitor-widget-shell a { display: block; }
+
+.visitor-external {
+  display: inline-block;
+  margin-top: 10px;
+  font-size: 11.5px;
+  color: var(--text-muted);
+  border-bottom: 1px dashed transparent;
+  transition: color .18s ease, border-color .18s ease;
+}
+.visitor-external:hover {
+  color: var(--purple);
+  border-bottom-color: var(--purple);
+  text-decoration: none;
+}
+
+@media (max-width: 720px) {
+  .footer-row { grid-template-columns: 1fr; text-align: center; }
+  .visitor-details { justify-self: center; width: 100%; }
+  .visitor-summary { width: auto; }
+  .visitor-panel { width: 100%; margin-left: auto; margin-right: auto; }
+}
 
 /* ── Responsive ── */
 @media (max-width: 860px) {


### PR DESCRIPTION
Port the ClustrMaps visitor widget back from the old site, styled as a discreet collapsible panel. Default state shows a small "Global readership" pill in the footer; expanding reveals the map with a click-through to the full interactive ClustrMaps dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a collapsible "Global readership" section to the footer with an interactive visitor map widget
* Added an expandable link to access the interactive map

## Style
* Redesigned footer layout with improved responsive styling for mobile devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->