### PR TITLE
fix: constrain ClustrMaps widget to panel width

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -131,7 +131,7 @@
           <div class="visitor-subtitle">Tracked since 2023 · click the map for details</div>
         </div>
         <div class="visitor-widget-shell">
-          <script type="text/javascript" id="clustrmaps" src="//clustrmaps.com/map_v2.js?d=o89zY8a0ARtuHIK-X34murs3PrRBFGrB1jTX7j2kYt8&cl=ffffff&w=a"></script>
+          <script type="text/javascript" id="clustrmaps" src="//clustrmaps.com/map_v2.js?d=o89zY8a0ARtuHIK-X34murs3PrRBFGrB1jTX7j2kYt8&cl=ffffff&w=380"></script>
         </div>
         <a class="visitor-external" id="visitor-external" href="#" target="_blank" rel="noopener" hidden>Open interactive map ↗</a>
       </div>

--- a/index.html
+++ b/index.html
@@ -554,7 +554,7 @@
           <div class="visitor-subtitle">Tracked since 2023 · click the map for details</div>
         </div>
         <div class="visitor-widget-shell">
-          <script type="text/javascript" id="clustrmaps" src="//clustrmaps.com/map_v2.js?d=o89zY8a0ARtuHIK-X34murs3PrRBFGrB1jTX7j2kYt8&cl=ffffff&w=a"></script>
+          <script type="text/javascript" id="clustrmaps" src="//clustrmaps.com/map_v2.js?d=o89zY8a0ARtuHIK-X34murs3PrRBFGrB1jTX7j2kYt8&cl=ffffff&w=380"></script>
         </div>
         <a class="visitor-external" id="visitor-external" href="#" target="_blank" rel="noopener" hidden>Open interactive map ↗</a>
       </div>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -706,10 +706,13 @@ footer a { color: var(--text-muted); }
   margin-top: 12px;
   padding: 16px;
   width: min(420px, 92vw);
+  max-width: min(420px, 92vw);
   border: 1px solid var(--border);
   border-radius: 16px;
   background: var(--bg-alt);
   box-shadow: 0 6px 20px rgba(15, 23, 42, 0.06);
+  overflow: hidden;
+  box-sizing: border-box;
 }
 html[data-theme="dark"] .visitor-panel {
   background: rgba(255, 255, 255, 0.03);
@@ -726,10 +729,17 @@ html[data-theme="dark"] .visitor-panel {
   opacity: 0.82;
   transition: opacity .2s ease;
   cursor: pointer;
+  max-width: 100%;
 }
 .visitor-widget-shell:hover { opacity: 1; }
-.visitor-widget-shell img { max-width: 100%; height: auto; display: block; }
-.visitor-widget-shell a { display: block; }
+.visitor-widget-shell img,
+.visitor-widget-shell svg,
+.visitor-widget-shell canvas {
+  max-width: 100% !important;
+  height: auto !important;
+  display: block;
+}
+.visitor-widget-shell a { display: block; max-width: 100%; }
 
 .visitor-external {
   display: inline-block;


### PR DESCRIPTION
Replace w=a (auto/full-width) with w=380 pixel cap and add defensive overflow/max-width on .visitor-panel and .visitor-widget-shell so the widget can't escape the footer container.